### PR TITLE
Add README and GH Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# DFAM Web Synth
+
+This project is a simple web-based recreation of the Moog DFAM (Drummer From Another Mother) synthesizer. The interface and controls mimic the original hardware so you can experiment with sound synthesis directly in your browser.
+
+## Enabling GitHub Pages
+
+1. Open the repository on GitHub and go to **Settings**.
+2. Select **Pages** from the sidebar.
+3. Under **Build and deployment**, choose **GitHub Actions** as the source.
+4. Save the configuration. GitHub Pages will be enabled at a URL in the form `https://<username>.github.io/<repository>`.
+
+## Deployment Workflow
+
+A workflow file located at `.github/workflows/deploy.yml` automatically deploys the site whenever you push to the `main` branch. The workflow:
+
+1. Checks out the repository.
+2. Sets up GitHub Pages and uploads the site files as an artifact.
+3. Deploys the artifact to the `gh-pages` environment using the `actions/deploy-pages` action.
+
+After the workflow completes, your updated site will be live on GitHub Pages.


### PR DESCRIPTION
## Summary
- add a README with project info and instructions on enabling GitHub Pages
- create `deploy.yml` GitHub Actions workflow to upload and deploy the site

## Testing
- `git status --short`