### PR TITLE
Fix preset save/load

### DIFF
--- a/synth.js
+++ b/synth.js
@@ -490,6 +490,14 @@ function addEventListeners() {
         document.getElementById('settingsOverlay').style.display = 'none';
     });
 
+    // Preset speichern und laden
+    document.getElementById('saveButton').addEventListener('click', () => {
+        saveSettings();
+    });
+    document.getElementById('loadButton').addEventListener('click', () => {
+        loadSettings();
+    });
+
     // Share Button
     document.getElementById('shareButton').addEventListener('click', () => {
         shareSettings();


### PR DESCRIPTION
## Summary
- wire up the Preset save/load controls in the settings overlay

## Testing
- `node --check synth.js`
