### PR TITLE
Fix GitHub Pages artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,9 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-artifact@v3.0.0
         with:
+          name: github-pages
           path: .
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This project is a simple web-based recreation of the Moog DFAM (Drummer From Ano
 A workflow file located at `.github/workflows/deploy.yml` automatically deploys the site whenever you push to the `main` branch. The workflow:
 
 1. Checks out the repository.
-2. Sets up GitHub Pages and uploads the site files as an artifact.
+2. Sets up GitHub Pages and uploads the site files as an artifact using the
+   `actions/upload-artifact@v3.0.0` action.
 3. Deploys the artifact to the `gh-pages` environment using the `actions/deploy-pages` action.
 
 After the workflow completes, your updated site will be live on GitHub Pages.


### PR DESCRIPTION
## Summary
- pin `actions/upload-artifact` at version `3.0.0` in the deploy workflow
- document the pinned action in the README

## Testing
- `npm test` *(fails: Could not read package.json)*